### PR TITLE
Enhance Daily Status Calculation Logic

### DIFF
--- a/src/main/java/com/stocks/aggregator/AggregatorApplication.java
+++ b/src/main/java/com/stocks/aggregator/AggregatorApplication.java
@@ -1,6 +1,7 @@
 package com.stocks.aggregator;
 
 import com.stocks.aggregator.api.influx.InfluxDBService;
+import com.stocks.aggregator.monitor_status.DayTradeStatusLoader;
 import com.stocks.aggregator.position_monitor.TradePositionLoader;
 import com.stocks.aggregator.revolut.RevolutPrinter;
 import com.stocks.aggregator.revolut.RevolutService;
@@ -31,6 +32,7 @@ public class AggregatorApplication implements CommandLineRunner {
     private final InfluxDBService influxDBService;
     private final RevolutPrinter revolutPrinter;
     private final TradePositionLoader tradePositionLoader;
+    private final DayTradeStatusLoader dayTradeStatusLoader;
 
     public static void main(String[] args) {
         SpringApplication.run(AggregatorApplication.class, args);
@@ -50,7 +52,9 @@ public class AggregatorApplication implements CommandLineRunner {
 //                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/revolut_2.csv", revolutStatementUpload),
 //                () -> revolutService.getRentExpensesByMonth()
         );
-        tradePositionLoader.loadClosedPosition(LocalDateTime.now().minusMonths(10), LocalDateTime.now());
+//        tradePositionLoader.loadClosedPosition(LocalDateTime.now().minusMonths(10), LocalDateTime.now());
+        dayTradeStatusLoader.loadDayTradeStatus();
+
 
 //        for (Runnable task : tasks) {
 //            task.run();

--- a/src/main/java/com/stocks/aggregator/AggregatorApplication.java
+++ b/src/main/java/com/stocks/aggregator/AggregatorApplication.java
@@ -1,7 +1,7 @@
 package com.stocks.aggregator;
 
-import com.stocks.aggregator.influx.InfluxDBService;
-import com.stocks.aggregator.etoro.model.DayTradeStatus;
+import com.stocks.aggregator.api.influx.InfluxDBService;
+import com.stocks.aggregator.position_monitor.TradePositionLoader;
 import com.stocks.aggregator.revolut.RevolutPrinter;
 import com.stocks.aggregator.revolut.RevolutService;
 import com.stocks.aggregator.etoro.DayTradeStatusService;
@@ -9,12 +9,12 @@ import com.stocks.aggregator.etoro.MonthTradeStatusService;
 import com.stocks.aggregator.etoro.AccountActivityUpload;
 import com.stocks.aggregator.etoro.ClosedTradePositionUpload;
 import com.stocks.aggregator.revolut.RevolutStatementUpload;
-import com.stocks.aggregator.utils.GoogleSheetExtractor;
 import lombok.AllArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @SpringBootApplication
@@ -30,6 +30,7 @@ public class AggregatorApplication implements CommandLineRunner {
     private final RevolutService revolutService;
     private final InfluxDBService influxDBService;
     private final RevolutPrinter revolutPrinter;
+    private final TradePositionLoader tradePositionLoader;
 
     public static void main(String[] args) {
         SpringApplication.run(AggregatorApplication.class, args);
@@ -40,20 +41,21 @@ public class AggregatorApplication implements CommandLineRunner {
         List<Runnable> tasks = List.of(
 //                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/ac_24.csv", accountActivityUpload),
 //                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/cp_24.csv", closedTradePositionUpload),
-                dayTradeStatusService::syncDayTradingInfo,
+//                dayTradeStatusService::syncDayTradingInfo,
 //                dayTradeStatusService::deleteDuplicates\
 //                dayTradeStatusService::calculateAndPopulateBalanceChange,
 //                dayTradeStatusService::calculateAndPopulateAvgProfitMonth
 //                dayTradeStatusService::calculateAndPopulateAvgBalanceChange
-                monthTradeStatusService::syncMonthTradeStatus
+//                monthTradeStatusService::syncMonthTradeStatus
 //                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/revolut_2.csv", revolutStatementUpload),
 //                () -> revolutService.getRentExpensesByMonth()
         );
+        tradePositionLoader.loadClosedPosition(LocalDateTime.now().minusMonths(10), LocalDateTime.now());
 
-        for (Runnable task : tasks) {
-            task.run();
-            Thread.sleep(1000); // Optional delay between tasks
-        }
+//        for (Runnable task : tasks) {
+//            task.run();
+//            Thread.sleep(1000); // Optional delay between tasks
+//        }
 //        revolutService.printRentExpensesByMonth();
 //
 //        List<DayTradeStatus> dayTradeStatuses = dayTradeStatusService.getAllOrderByDateAsc();

--- a/src/main/java/com/stocks/aggregator/AggregatorApplication.java
+++ b/src/main/java/com/stocks/aggregator/AggregatorApplication.java
@@ -38,8 +38,8 @@ public class AggregatorApplication implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         List<Runnable> tasks = List.of(
-//                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/Account Activity_2.csv", accountActivityUpload),
-//                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/Closed Positions_2.csv", closedTradePositionUpload),
+//                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/ac_24.csv", accountActivityUpload),
+//                () -> GoogleSheetExtractor.importCSV("src/main/resources/reports/cp_24.csv", closedTradePositionUpload),
                 dayTradeStatusService::syncDayTradingInfo,
 //                dayTradeStatusService::deleteDuplicates\
 //                dayTradeStatusService::calculateAndPopulateBalanceChange,

--- a/src/main/java/com/stocks/aggregator/api/influx/InfluxDBService.java
+++ b/src/main/java/com/stocks/aggregator/api/influx/InfluxDBService.java
@@ -1,10 +1,9 @@
-package com.stocks.aggregator.influx;
+package com.stocks.aggregator.api.influx;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 import com.stocks.aggregator.etoro.model.DayTradeStatus;
-import com.stocks.aggregator.revolut.model.RevolutStatement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +12,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/stocks/aggregator/etoro/repo/ClosedTradePositionRepository.java
+++ b/src/main/java/com/stocks/aggregator/etoro/repo/ClosedTradePositionRepository.java
@@ -1,6 +1,7 @@
 package com.stocks.aggregator.etoro.repo;
 
 import com.stocks.aggregator.etoro.model.ClosedTradePosition;
+import com.stocks.aggregator.position_monitor.TradePositionProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,6 +31,34 @@ public interface ClosedTradePositionRepository extends JpaRepository<ClosedTrade
     @Query("SELECT c FROM ClosedTradePosition c WHERE c.closeDate BETWEEN :startOfDay AND :endOfDay")
     List<ClosedTradePosition> findClosedPositionsByDay(@Param("startOfDay") LocalDateTime startOfDay,
                                                        @Param("endOfDay") LocalDateTime endOfDay);
+
+
+    List<ClosedTradePosition> findClosedTradePositionsByOpenDateAfter(LocalDateTime startOpenDay);
+
+    @Query("""
+                SELECT 
+                    c.positionId AS positionId,
+                    c.amount AS amount,
+                    c.openDate AS openDate,
+                    c.closeDate AS closeDate,
+                    c.leverage AS leverage,
+                    c.action AS action,
+                    c.openRate AS openRate,
+                    c.closeRate AS closeRate,
+                    c.takeProfitRate AS takeProfitRate,
+                    c.stopLossRate AS stopLossRate,
+                    c.profitUsd AS profitUsd,
+                    c.longShort AS longShort,
+                    c.units AS units,
+                    a.balance AS balance,
+                    a.realizedEquity AS realizedEquity,
+                    a.type AS type
+                FROM ClosedTradePosition c
+                JOIN AccountActivity a ON c.positionId = a.positionId
+                WHERE c.openDate BETWEEN :startOpenDay AND :endOpenDay and a.type='Position closed'
+                ORDER BY c.closeDate DESC
+            """)
+    List<TradePositionProjection> findProjectedByOpenDateBetween(LocalDateTime startOpenDay, LocalDateTime endOpenDay);
 
 
 

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusId.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusId.java
@@ -1,0 +1,18 @@
+package com.stocks.aggregator.monitor_status;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DayTradeStatusId implements Serializable {
+
+    private LocalDate tradeDate;
+    private long totalTrades;
+}
+

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusLoader.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusLoader.java
@@ -1,0 +1,36 @@
+package com.stocks.aggregator.monitor_status;
+
+import com.stocks.aggregator.position_monitor.TradePositionRecord;
+import com.stocks.aggregator.position_monitor.TradePositionRecordRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@AllArgsConstructor
+public class DayTradeStatusLoader {
+
+    private TradePositionRecordRepository repository;
+
+    void loadDayTradeStatus() {
+        loadTradeRecordsGroupedByMonth().forEach((month, tradePositionRecords) -> {
+
+        });
+    }
+
+    public Map<String, List<TradePositionRecord>> loadTradeRecordsGroupedByMonth() {
+        List<TradePositionRecord> allRecords = repository.findAll();
+
+        return allRecords.stream()
+                .collect(Collectors.groupingBy(TradePositionRecord::getMonth));
+    }
+
+    void computeMonth(List<TradePositionRecord> transactionRecords) {
+        DayTradeStatusRecord dayTradeStatusRecord = new DayTradeStatusRecord();
+
+    }
+
+}

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusLoader.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusLoader.java
@@ -94,7 +94,7 @@ public class DayTradeStatusLoader {
             }
         }
 
-     //   monthlyProfit += totalProfitUsd;
+        //   monthlyProfit += totalProfitUsd;
         int totalTrades = tradeRecords.size();
         double winRatePercent = (winCount + lossCount > 0)
                 ? ((double) winCount / (winCount + lossCount)) * 100
@@ -107,7 +107,7 @@ public class DayTradeStatusLoader {
                 .totalProfit(totalProfitUsd)
                 .profitRate(winRatePercent)
                 .averageMonthlyProfit(monthlyProfit / monthlyCount)
-                .averageWinDayPip(MathUtils.calculateMean(pipsPerTrade))
+                .averageWinDayPip(MathUtils.trimmedMean(pipsPerTrade, 0.1))
                 .realisedEquity(endingEquity)
                 .realisedEquityChange(MathUtils.calculatePercentChange(startingEquity, endingEquity))
                 .wonTrades(winCount)

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusLoader.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusLoader.java
@@ -2,9 +2,12 @@ package com.stocks.aggregator.monitor_status;
 
 import com.stocks.aggregator.position_monitor.TradePositionRecord;
 import com.stocks.aggregator.position_monitor.TradePositionRecordRepository;
+import com.stocks.aggregator.utils.MathUtils;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,12 +17,42 @@ import java.util.stream.Collectors;
 public class DayTradeStatusLoader {
 
     private TradePositionRecordRepository repository;
+    private DayTradeStatusRecordRepository dayTradeStatusRecordRepository;
 
-    void loadDayTradeStatus() {
+    public void loadDayTradeStatus() {
         loadTradeRecordsGroupedByMonth().forEach((month, tradePositionRecords) -> {
 
+            System.out.println("Month: " + month);
+
+            // Group by day and sort days chronologically based on closeDate of first trade
+            Map<String, List<TradePositionRecord>> dayRecords = tradePositionRecords.stream()
+                    .collect(Collectors.groupingBy(TradePositionRecord::getDay));
+
+            List<Map.Entry<String, List<TradePositionRecord>>> sortedEntries = new ArrayList<>(dayRecords.entrySet());
+
+            // Sort by the closeDate of the first trade in each day
+            sortedEntries.sort(Comparator.comparing(e -> e.getValue().get(0).getCloseDate()));
+
+            double monthlyProfit = 0.0;
+
+            for (int i = 0; i < sortedEntries.size(); i++) {
+                Map.Entry<String, List<TradePositionRecord>> entry = sortedEntries.get(i);
+                String day = entry.getKey();
+                List<TradePositionRecord> tradesOfTheDay = entry.getValue();
+
+                double dailyProfit = tradesOfTheDay.stream()
+                        .mapToDouble(TradePositionRecord::getProfitUsd)
+                        .sum();
+
+                monthlyProfit += dailyProfit;
+
+                System.out.printf("  Day: %s | Daily Profit: %.2f | Monthly Accumulated: %.2f%n", day, dailyProfit, monthlyProfit);
+
+                computeDayRecords(day, tradesOfTheDay, monthlyProfit, i + 1);
+            }
         });
     }
+
 
     public Map<String, List<TradePositionRecord>> loadTradeRecordsGroupedByMonth() {
         List<TradePositionRecord> allRecords = repository.findAll();
@@ -28,8 +61,63 @@ public class DayTradeStatusLoader {
                 .collect(Collectors.groupingBy(TradePositionRecord::getMonth));
     }
 
-    void computeMonth(List<TradePositionRecord> transactionRecords) {
-        DayTradeStatusRecord dayTradeStatusRecord = new DayTradeStatusRecord();
+    void computeDayRecords(String day, List<TradePositionRecord> tradeRecords, double monthlyProfit, int monthlyCount) {
+        if (tradeRecords == null || tradeRecords.isEmpty()) {
+            throw new IllegalArgumentException("Trade records must not be null or empty");
+        }
+
+        TradePositionRecord firstTrade = tradeRecords.get(0);
+        TradePositionRecord lastTrade = tradeRecords.get(tradeRecords.size() - 1);
+        TradePositionRecord previousDayTrade = repository.findByPositionId(firstTrade.getPositionId());
+
+        double startingEquity = previousDayTrade.getRealizedEquity();
+        double endingEquity = lastTrade.getRealizedEquity();
+
+        double totalProfitUsd = 0.0;
+        List<Integer> pipsPerTrade = new ArrayList<>();
+        int winCount = 0;
+        int lossCount = 0;
+        double totalWinUsd = 0.0;
+        double totalLossUsd = 0.0;
+
+        for (TradePositionRecord record : tradeRecords) {
+            double profitUsd = record.getProfitUsd();
+            totalProfitUsd += profitUsd;
+            pipsPerTrade.add(record.getPips());
+
+            if (profitUsd > 0) {
+                winCount++;
+                totalWinUsd += profitUsd;
+            } else {
+                lossCount++;
+                totalLossUsd += profitUsd;
+            }
+        }
+
+     //   monthlyProfit += totalProfitUsd;
+        int totalTrades = tradeRecords.size();
+        double winRatePercent = (winCount + lossCount > 0)
+                ? ((double) winCount / (winCount + lossCount)) * 100
+                : 0.0;
+
+        DayTradeStatusRecord dayStatus = DayTradeStatusRecord.builder()
+                .day(day)
+                .tradeDate(firstTrade.getCloseDate().toLocalDate())
+                .totalTrades(totalTrades)
+                .totalProfit(totalProfitUsd)
+                .profitRate(winRatePercent)
+                .averageMonthlyProfit(monthlyProfit / monthlyCount)
+                .averageWinDayPip(MathUtils.calculateMean(pipsPerTrade))
+                .realisedEquity(endingEquity)
+                .realisedEquityChange(MathUtils.calculatePercentChange(startingEquity, endingEquity))
+                .wonTrades(winCount)
+                .lostTrades(lossCount)
+                .totalWonValue(totalWinUsd)
+                .totalLostValue(totalLossUsd)
+                .monthlyProfit(monthlyProfit)
+                .build();
+
+        dayTradeStatusRecordRepository.save(dayStatus);
 
     }
 

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusRecord.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusRecord.java
@@ -1,13 +1,19 @@
 package com.stocks.aggregator.monitor_status;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "day_trade_status_records")
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @IdClass(DayTradeStatusId.class)
 public class DayTradeStatusRecord {
 
@@ -27,8 +33,13 @@ public class DayTradeStatusRecord {
     @Column(name = "profit_rate")
     private double profitRate;
 
+    @Column(name = "monthly_profit")
+    private double monthlyProfit;
     @Column(name = "average_monthly_profit")
     private double averageMonthlyProfit;
+
+    @Column(name = "average_win_day_pip")
+    private double averageWinDayPip;
 
     @Column(name = "realised_equity")
     private double realisedEquity;
@@ -59,4 +70,5 @@ public class DayTradeStatusRecord {
 
     @Column(name = "position_fee")
     private double positionFee;
+
 }

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusRecord.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusRecord.java
@@ -1,0 +1,62 @@
+package com.stocks.aggregator.monitor_status;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "day_trade_status_records")
+@Data
+@IdClass(DayTradeStatusId.class)
+public class DayTradeStatusRecord {
+
+    @Column(name = "trade_day", nullable = false)
+    String day;
+    @Id
+    @Column(name = "trade_date", nullable = false)
+    private LocalDate tradeDate;
+
+    @Id
+    @Column(name = "total_trades")
+    private long totalTrades;
+
+    @Column(name = "total_profit")
+    private double totalProfit;
+
+    @Column(name = "profit_rate")
+    private double profitRate;
+
+    @Column(name = "average_monthly_profit")
+    private double averageMonthlyProfit;
+
+    @Column(name = "realised_equity")
+    private double realisedEquity;
+
+    @Column(name = "realised_equity_change")
+    private double realisedEquityChange;
+
+    @Column(name = "lost_trades")
+    private double lostTrades;
+
+    @Column(name = "won_trades")
+    private double wonTrades;
+
+    @Column(name = "total_won_value")
+    private double totalWonValue;
+
+    @Column(name = "total_lost_value")
+    private double totalLostValue;
+
+    @Column(name = "total_deposit")
+    private double totalDeposit;
+
+    @Column(name = "total_withdraw")
+    private double totalWithdraw;
+
+    @Column(name = "deposit_withdraw_fee")
+    private double depositWithdrawFee;
+
+    @Column(name = "position_fee")
+    private double positionFee;
+}

--- a/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusRecordRepository.java
+++ b/src/main/java/com/stocks/aggregator/monitor_status/DayTradeStatusRecordRepository.java
@@ -1,0 +1,15 @@
+package com.stocks.aggregator.monitor_status;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface DayTradeStatusRecordRepository extends JpaRepository<DayTradeStatusRecord, DayTradeStatusId> {
+
+    Optional<DayTradeStatusRecord> findByTradeDate(LocalDate tradeDate);
+
+    // Add any custom query methods you need here
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionKey.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionKey.java
@@ -1,0 +1,13 @@
+package com.stocks.aggregator.position_monitor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradePositionKey implements Serializable {
+    private Long positionId;
+    private LocalDateTime closeDate;
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionLoader.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionLoader.java
@@ -1,0 +1,54 @@
+package com.stocks.aggregator.position_monitor;
+
+import com.stocks.aggregator.etoro.repo.ClosedTradePositionRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.LinkedHashSet;
+
+@Component
+@AllArgsConstructor
+public class TradePositionLoader {
+
+    private ClosedTradePositionRepository closedRepository;
+    private TradePositionRecordRepository repository;
+
+    public void loadClosedPosition(LocalDateTime startLoadingDate, LocalDateTime endLoadingDate) {
+        List<TradePositionProjection> positionProjections = closedRepository.findProjectedByOpenDateBetween(startLoadingDate, endLoadingDate);
+
+        Set<TradePositionProjection> uniqueProjections = positionProjections.stream()
+                .collect(Collectors.toMap(
+                        p -> p.getPositionId() + "|" + p.getCloseDate(), // Composite key
+                        p -> p,
+                        (existing, replacement) -> existing // Keep first
+                ))
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(TradePositionProjection::getCloseDate).reversed())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<TradePositionRecordDto> tradePositionRecordDtos = uniqueProjections.stream()
+                .map(TradePositionProjectionMapper.INSTANCE)
+                .toList();
+
+
+        tradePositionRecordDtos.forEach(System.out::println);
+
+        tradePositionRecordDtos.forEach(tradePositionRecordDto -> repository.save(TradePositionMapper.toEntity(tradePositionRecordDto)));
+
+        System.out.println(uniqueProjections.size());
+//        uniqueProjections.stream().forEach(tradePositionProjection -> System.out.println(tradePositionProjection.toStringFormatted()));
+
+
+        // Calculate Trade position record
+
+
+    }
+
+
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionLoader.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionLoader.java
@@ -1,54 +1,55 @@
 package com.stocks.aggregator.position_monitor;
 
 import com.stocks.aggregator.etoro.repo.ClosedTradePositionRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.LinkedHashSet;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TradePositionLoader {
 
-    private ClosedTradePositionRepository closedRepository;
-    private TradePositionRecordRepository repository;
+    private final ClosedTradePositionRepository closedRepository;
+    private final TradePositionRecordRepository repository;
 
     public void loadClosedPosition(LocalDateTime startLoadingDate, LocalDateTime endLoadingDate) {
-        List<TradePositionProjection> positionProjections = closedRepository.findProjectedByOpenDateBetween(startLoadingDate, endLoadingDate);
+        List<TradePositionProjection> projections = closedRepository.findProjectedByOpenDateBetween(startLoadingDate, endLoadingDate);
 
-        Set<TradePositionProjection> uniqueProjections = positionProjections.stream()
+        // De-duplicate by positionId + closeDate, then sort by closeDate descending
+        List<TradePositionProjection> sortedUniqueProjections = projections.stream()
                 .collect(Collectors.toMap(
-                        p -> p.getPositionId() + "|" + p.getCloseDate(), // Composite key
+                        p -> p.getPositionId() + "|" + p.getCloseDate(),
                         p -> p,
-                        (existing, replacement) -> existing // Keep first
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
                 ))
                 .values()
                 .stream()
-                .sorted(Comparator.comparing(TradePositionProjection::getCloseDate).reversed())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        List<TradePositionRecordDto> tradePositionRecordDtos = uniqueProjections.stream()
-                .map(TradePositionProjectionMapper.INSTANCE)
+                .sorted(Comparator.comparing(TradePositionProjection::getCloseDate))
                 .toList();
 
+        // Track previous positionId to set as lastPositionId
+        AtomicReference<Long> previousIdRef = new AtomicReference<>(null);
 
-        tradePositionRecordDtos.forEach(System.out::println);
+        List<TradePositionRecord> recordsToSave = sortedUniqueProjections.stream()
+                .map(projection -> {
+                    var dto = TradePositionProjectionMapper.INSTANCE.apply(projection);
+                    if (projection.getLastPositionId() == null) {
+                        dto.setLastPositionId(previousIdRef.get());
+                        previousIdRef.set(projection.getPositionId());
+                    }
+                    return TradePositionMapper.toEntity(dto);
+                })
+                .toList();
 
-        tradePositionRecordDtos.forEach(tradePositionRecordDto -> repository.save(TradePositionMapper.toEntity(tradePositionRecordDto)));
-
-        System.out.println(uniqueProjections.size());
-//        uniqueProjections.stream().forEach(tradePositionProjection -> System.out.println(tradePositionProjection.toStringFormatted()));
-
-
-        // Calculate Trade position record
-
-
+        // Save all records
+        repository.saveAll(recordsToSave);
     }
-
-
 }
+

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionMapper.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionMapper.java
@@ -34,6 +34,7 @@ public class TradePositionMapper {
                 .positionRisk(dto.getPositionRisk())
                 .riskToRewardRatio(dto.getRiskToRewardRatio())
                 .riskToReward(dto.getRiskToReward())
+                .lastPosition(dto.getLastPositionId())
                 .build();
     }
 

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionMapper.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionMapper.java
@@ -1,0 +1,40 @@
+package com.stocks.aggregator.position_monitor;
+
+public class TradePositionMapper {
+
+    public static TradePositionRecord toEntity(TradePositionRecordDto dto) {
+        return TradePositionRecord.builder()
+                .positionId(dto.getPositionId())
+                .amount(dto.getAmount())
+                .openDate(dto.getOpenDate())
+                .closeDate(dto.getCloseDate())
+                .leverage(dto.getLeverage())
+                .action(dto.getAction())
+                .openRate(dto.getOpenRate())
+                .closeRate(dto.getCloseRate())
+                .takeProfitRate(dto.getTakeProfitRate())
+                .stopLossRate(dto.getStopLossRate())
+                .profitUsd(dto.getProfitUsd())
+                .longShort(dto.getLongShort())
+
+                .balance(dto.getBalance())
+                .realizedEquity(dto.getRealizedEquity())
+                .type(dto.getType())
+                .day(dto.getDay())
+                .holdingTimeHour(dto.getHoldingTimeHour())
+                .holdingTimeMinutes(dto.getHoldingTimeMinutes())
+                .pips(dto.getPips())
+                .profitPercent(dto.getProfitPercent())
+                .profitPercentAccount(dto.getProfitPercentAccount())
+                .openPercentRisk(dto.getOpenPercentRisk())
+
+                .month(dto.getMonth() != null ? dto.getMonth().toString() : null)
+                .week(dto.getWeek())
+
+                .positionRisk(dto.getPositionRisk())
+                .riskToRewardRatio(dto.getRiskToRewardRatio())
+                .riskToReward(dto.getRiskToReward())
+                .build();
+    }
+
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjection.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjection.java
@@ -1,0 +1,43 @@
+package com.stocks.aggregator.position_monitor;
+
+import java.time.LocalDateTime;
+
+public interface TradePositionProjection {
+
+    Long getPositionId();
+    Double getAmount();
+    LocalDateTime getOpenDate();
+    LocalDateTime getCloseDate();
+    Double getLeverage();
+    String getAction();
+    Double getOpenRate();
+    Double getCloseRate();
+    Double getTakeProfitRate();
+    Double getStopLossRate();
+    Double getProfitUsd();
+    String getLongShort();
+    Double getBalance();
+    Double getRealizedEquity();
+    String getType();
+    Double getUnits();
+
+    default String toStringFormatted() {
+        return "TradePositionProjection{" +
+                "positionId=" + getPositionId() +
+                ", amount=" + getAmount() +
+                ", openDate=" + getOpenDate() +
+                ", closeDate=" + getCloseDate() +
+                ", leverage=" + getLeverage() +
+                ", action='" + getAction() + '\'' +
+                ", openRate=" + getOpenRate() +
+                ", closeRate=" + getCloseRate() +
+                ", takeProfitRate=" + getTakeProfitRate() +
+                ", stopLossRate=" + getStopLossRate() +
+                ", profitUsd=" + getProfitUsd() +
+                ", longShort='" + getLongShort() + '\'' +
+                ", balance=" + getBalance() +
+                ", realizedEquity=" + getRealizedEquity() +
+                ", type='" + getType() + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjection.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjection.java
@@ -20,6 +20,8 @@ public interface TradePositionProjection {
     Double getRealizedEquity();
     String getType();
     Double getUnits();
+    Long getLastPositionId();
+
 
     default String toStringFormatted() {
         return "TradePositionProjection{" +

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjectionMapper.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjectionMapper.java
@@ -1,0 +1,166 @@
+package com.stocks.aggregator.position_monitor;
+
+import java.time.Duration;
+import java.time.YearMonth;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import java.util.function.Function;
+
+public class TradePositionProjectionMapper implements Function<TradePositionProjection, TradePositionRecordDto> {
+
+    public static final TradePositionProjectionMapper INSTANCE = new TradePositionProjectionMapper();
+
+    @Override
+    public TradePositionRecordDto apply(TradePositionProjection p) {
+        int holdingTimeHour = calculateHoldingHours(p);
+        int pips = calculatePips(p);
+        double profitPercent = calculateProfitPercent(p);
+        YearMonth month = p.getCloseDate() != null ? YearMonth.from(p.getCloseDate()) : null;
+        String week = formatWeek(p);
+
+        return TradePositionRecordDto.builder()
+                .positionId(p.getPositionId())
+                .amount(p.getAmount())
+                .openDate(p.getOpenDate())
+                .closeDate(p.getCloseDate())
+                .leverage(p.getLeverage())
+                .action(p.getAction())
+                .openRate(p.getOpenRate())
+                .closeRate(p.getCloseRate())
+                .takeProfitRate(p.getTakeProfitRate())
+                .stopLossRate(p.getStopLossRate())
+                .profitUsd(p.getProfitUsd())
+                .longShort(p.getLongShort())
+                .balance(p.getBalance())
+                .realizedEquity(p.getRealizedEquity())
+                .type(p.getType())
+                .holdingTimeMinutes(calculateHoldingMinutes(p))
+                .holdingTimeHour(holdingTimeHour)
+                .pips(pips)
+                .profitPercent(profitPercent)
+                .profitPercentAccount(calculateProfitPercentAccount(p))
+                .openPercentRisk(calculateOpenPercentRisk(p))
+                .positionRisk(calculatePositionRisk(p))
+                .riskToRewardRatio(calculateRiskToRewardRatio(p))
+                .riskToReward(calculateRiskToReward(p))
+                .month(month)
+                .week(week)
+                .day(formatDay(p))
+                .build();
+    }
+
+    private double calculateProfitPercentAccount(TradePositionProjection p) {
+        if (p.getProfitUsd() == null || p.getRealizedEquity() == null || p.getRealizedEquity() == 0) {
+            return 0.0;
+        }
+        double percent = (p.getProfitUsd() / p.getRealizedEquity()) * 100;
+        return Math.round(percent * 100.0) / 100.0; // round to 2 decimals
+    }
+
+    private double calculateOpenPercentRisk(TradePositionProjection p) {
+        if (p.getAmount() == null || p.getRealizedEquity() == null || p.getRealizedEquity() == 0) {
+            return 0.0;
+        }
+        double percent = (p.getAmount() / p.getRealizedEquity()) * 100;
+        return Math.round(percent * 100.0) / 100.0; // round to 2 decimals
+    }
+
+    private String calculateRiskToReward(TradePositionProjection p) {
+        if (p.getTakeProfitRate() == null || p.getStopLossRate() == null || p.getOpenRate() == null) {
+            return "1:0";
+        }
+
+        double risk = Math.abs(p.getOpenRate() - p.getStopLossRate());
+        if (risk == 0) return "1:0"; // avoid division by zero
+
+        double reward = Math.abs(p.getTakeProfitRate() - p.getOpenRate());
+        double ratio = reward / risk;
+
+        return "1:" + String.format("%.2f", ratio);
+    }
+
+    private double calculatePositionRisk(TradePositionProjection p) {
+        // Assumptions
+        double contractSize = p.getUnits(); // If you have real value, inject it
+        int positionSize = 1;      // Optional if you expand TradePositionProjection
+        double portfolioValue = p.getRealizedEquity() != null ? p.getRealizedEquity() : 0.0;
+
+        if (p.getStopLossRate() == null || p.getOpenRate() == null || portfolioValue == 0) {
+            return 0.0;
+        }
+
+        double stopLossDistance = Math.abs(p.getOpenRate() - p.getStopLossRate());
+        double totalRisk = stopLossDistance * contractSize * positionSize;
+
+        double riskPercent = (totalRisk / portfolioValue) * 100;
+        return Math.round(riskPercent * 100.0) / 100.0; // Rounded to 2 decimals
+    }
+
+    private double calculateRiskToRewardRatio(TradePositionProjection p) {
+        if (p.getTakeProfitRate() == null || p.getStopLossRate() == null || p.getOpenRate() == null) {
+            return 0.0;
+        }
+
+        double risk = Math.abs(p.getOpenRate() - p.getStopLossRate());
+        if (risk == 0) return 0.0; // avoid division by zero
+
+        double reward = Math.abs(p.getTakeProfitRate() - p.getOpenRate());
+        double ratio = reward / risk;
+
+        return Math.round(ratio * 100.0) / 100.0; // round to 2 decimals
+    }
+
+
+    private double calculateProfitPercent(TradePositionProjection p) {
+        if (p.getAmount() != null && p.getAmount() != 0 && p.getProfitUsd() != null) {
+            double rawPercent = (p.getProfitUsd() / p.getAmount()) * 100;
+            return Math.round(rawPercent * 100.0) / 100.0; // Round to 2 decimal places
+        }
+        return 0.0;
+    }
+
+    private int calculateHoldingHours(TradePositionProjection p) {
+        if (p.getOpenDate() != null && p.getCloseDate() != null) {
+            return (int) Duration.between(p.getOpenDate(), p.getCloseDate()).toHours();
+        }
+        return 0;
+    }
+
+    private int calculateHoldingMinutes(TradePositionProjection p) {
+        if (p.getOpenDate() != null && p.getCloseDate() != null) {
+            return (int) Duration.between(p.getOpenDate(), p.getCloseDate()).toMinutes();
+        }
+        return 0;
+    }
+
+    private int calculatePips(TradePositionProjection p) {
+        if (p.getOpenRate() != null && p.getCloseRate() != null) {
+            double diff = p.getCloseRate() - p.getOpenRate();
+            return (int) Math.abs(diff); // Assumes 4-digit pricing
+        }
+        return 0;
+    }
+
+    private String formatWeek(TradePositionProjection p) {
+        if (p.getCloseDate() != null) {
+            WeekFields weekFields = WeekFields.of(Locale.getDefault());
+            int weekNum = p.getCloseDate().get(weekFields.weekOfWeekBasedYear());
+            int year = p.getCloseDate().getYear();
+            int month = p.getCloseDate().getMonth().getValue();
+            int day = p.getCloseDate().getDayOfMonth();
+            return String.format("W%d",  weekNum);
+        }
+        return null;
+    }
+    private String formatDay(TradePositionProjection p){
+        if (p.getCloseDate() != null) {
+            WeekFields weekFields = WeekFields.of(Locale.getDefault());
+            int weekNum = p.getCloseDate().get(weekFields.weekOfWeekBasedYear());
+            int year = p.getCloseDate().getYear();
+            int month = p.getCloseDate().getMonth().getValue();
+            int day = p.getCloseDate().getDayOfMonth();
+            return String.format("D%d", day);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjectionMapper.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionProjectionMapper.java
@@ -45,6 +45,7 @@ public class TradePositionProjectionMapper implements Function<TradePositionProj
                 .riskToReward(calculateRiskToReward(p))
                 .month(month)
                 .week(week)
+                .lastPositionId(p.getLastPositionId())
                 .day(formatDay(p))
                 .build();
     }
@@ -148,11 +149,12 @@ public class TradePositionProjectionMapper implements Function<TradePositionProj
             int year = p.getCloseDate().getYear();
             int month = p.getCloseDate().getMonth().getValue();
             int day = p.getCloseDate().getDayOfMonth();
-            return String.format("W%d",  weekNum);
+            return String.format("W%d", weekNum);
         }
         return null;
     }
-    private String formatDay(TradePositionProjection p){
+
+    private String formatDay(TradePositionProjection p) {
         if (p.getCloseDate() != null) {
             WeekFields weekFields = WeekFields.of(Locale.getDefault());
             int weekNum = p.getCloseDate().get(weekFields.weekOfWeekBasedYear());

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecord.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecord.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 @Builder
 public class TradePositionRecord {
 
+
     @Id
     private Long positionId;
 
@@ -50,4 +51,8 @@ public class TradePositionRecord {
     private double positionRisk;
     private double riskToRewardRatio;
     private String riskToReward;
+
+    private Long lastPosition;
+
+
 }

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecord.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecord.java
@@ -1,0 +1,53 @@
+package com.stocks.aggregator.position_monitor;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trade_position_records")
+@IdClass(TradePositionKey.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TradePositionRecord {
+
+    @Id
+    private Long positionId;
+
+    @Id
+    private LocalDateTime closeDate;
+
+    private double amount;
+    private LocalDateTime openDate;
+    private double leverage;
+    private String action;
+    private double openRate;
+    private double closeRate;
+    private double takeProfitRate;
+    private double stopLossRate;
+    private double profitUsd;
+    private String longShort;
+
+    private double balance;
+    private double realizedEquity;
+    private String type;
+
+    private int holdingTimeHour;
+    private int holdingTimeMinutes;
+    private int pips;
+    private double profitPercent;
+    private double profitPercentAccount;
+    private double openPercentRisk;
+
+    private String month; // store as "YYYY-MM"
+    private String week;
+
+    private String day;
+
+    private double positionRisk;
+    private double riskToRewardRatio;
+    private String riskToReward;
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordDto.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordDto.java
@@ -1,0 +1,51 @@
+package com.stocks.aggregator.position_monitor;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+@Data
+public class TradePositionRecordDto {
+
+    private Long positionId;
+    private double amount;
+    private LocalDateTime openDate;
+    private LocalDateTime closeDate;
+    private double leverage;
+    private String action;
+    private double openRate;
+    private double closeRate;
+    private double takeProfitRate;
+    private double stopLossRate;
+    private double profitUsd;
+    private String longShort;
+
+    private double balance;
+    private double realizedEquity;
+    private String type;
+
+    private int holdingTimeHour;
+    private int holdingTimeMinutes;
+    private int pips;
+    private double profitPercent;
+    private double profitPercentAccount;
+    private double openPercentRisk;
+
+    private YearMonth month;
+    private String week;
+
+    private String day;
+
+    private double positionRisk;
+
+    private double riskToRewardRatio;
+    private String riskToReward;
+
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordDto.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordDto.java
@@ -14,6 +14,7 @@ import java.time.YearMonth;
 @Data
 public class TradePositionRecordDto {
 
+
     private Long positionId;
     private double amount;
     private LocalDateTime openDate;
@@ -47,5 +48,7 @@ public class TradePositionRecordDto {
 
     private double riskToRewardRatio;
     private String riskToReward;
+
+    private Long lastPositionId;
 
 }

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordRepository.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordRepository.java
@@ -1,0 +1,9 @@
+package com.stocks.aggregator.position_monitor;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TradePositionRecordRepository extends JpaRepository<TradePositionRecord, TradePositionKey> {
+    // Optional: Add custom query methods if needed
+}

--- a/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordRepository.java
+++ b/src/main/java/com/stocks/aggregator/position_monitor/TradePositionRecordRepository.java
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TradePositionRecordRepository extends JpaRepository<TradePositionRecord, TradePositionKey> {
     // Optional: Add custom query methods if needed
+
+    TradePositionRecord findByPositionId(Long positionId);
+
 }

--- a/src/main/java/com/stocks/aggregator/temp/ProfitCalculator.java
+++ b/src/main/java/com/stocks/aggregator/temp/ProfitCalculator.java
@@ -1,0 +1,73 @@
+package com.stocks.aggregator.temp;
+
+import java.util.Scanner;
+
+public class ProfitCalculator {
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+
+        // Input starting sum
+        System.out.print("Enter the starting sum: ");
+        double startingSum = scanner.nextDouble();
+
+        // Choose profit type
+        System.out.print("Is your daily profit a fixed amount or a percentage? (Enter 'fixed' or 'percent'): ");
+        String profitType = scanner.next();
+
+        double profitValue;
+        if (profitType.equalsIgnoreCase("fixed")) {
+            System.out.print("Enter the fixed daily profit: ");
+            profitValue = scanner.nextDouble();
+        } else {
+            System.out.print("Enter the daily profit percentage (e.g. 5 for 5%): ");
+            profitValue = scanner.nextDouble();
+        }
+
+        // Choose mode
+        System.out.println("Choose mode:");
+        System.out.println("1 - Enter target final sum");
+        System.out.println("2 - Enter number of days");
+        int mode = scanner.nextInt();
+
+        double currentSum = startingSum;
+        int days = 0;
+
+        if (mode == 1) {
+            // Mode 1: Target Sum Mode
+            System.out.print("Enter the target final sum: ");
+            double targetSum = scanner.nextDouble();
+
+            while (currentSum < targetSum) {
+                if (profitType.equalsIgnoreCase("fixed")) {
+                    currentSum += profitValue;
+                } else {
+                    currentSum += currentSum * (profitValue / 100);
+                }
+                days++;
+            }
+
+            System.out.printf("Final sum reached: %.2f%n", currentSum);
+            System.out.println("Days needed: " + days);
+
+        } else if (mode == 2) {
+            // Mode 2: Fixed Days Mode
+            System.out.print("Enter the number of days: ");
+            days = scanner.nextInt();
+
+            for (int i = 0; i < days; i++) {
+                if (profitType.equalsIgnoreCase("fixed")) {
+                    currentSum += profitValue;
+                } else {
+                    currentSum += currentSum * (profitValue / 100);
+                }
+            }
+
+            System.out.printf("Final sum after %d days: %.2f%n", days, currentSum);
+        } else {
+            System.out.println("Invalid mode selected.");
+        }
+
+        scanner.close();
+    }
+}

--- a/src/main/java/com/stocks/aggregator/utils/MathUtils.java
+++ b/src/main/java/com/stocks/aggregator/utils/MathUtils.java
@@ -7,9 +7,9 @@ import java.util.stream.IntStream;
 
 public class MathUtils {
 
-    public static  <T> void updateCumulativeAverage(List<T> records,
-                                             Function<T, Double> valueGetter,
-                                             BiConsumer<T, Double> valueSetter) {
+    public static <T> void updateCumulativeAverage(List<T> records,
+                                                   Function<T, Double> valueGetter,
+                                                   BiConsumer<T, Double> valueSetter) {
         double[] cumulativeValue = {0.0};
 
         IntStream.range(0, records.size()).forEach(i -> {
@@ -27,8 +27,32 @@ public class MathUtils {
         });
     }
 
-    private  static double roundToNDecimalPlaces(double value, int places) {
+    private static double roundToNDecimalPlaces(double value, int places) {
         return Math.round(value * Math.pow(10, places)) / Math.pow(10, places);
+    }
+
+    public static double calculatePercentChange(double startValue, double endValue) {
+        if (startValue != 0) {
+            return ((endValue - startValue) / startValue) * 100.0;
+        } else {
+            // Avoid division by zero, fallback logic
+            if (endValue > 0) return 100.0;
+            else if (endValue < 0) return -100.0;
+            else return 0.0;
+        }
+    }
+
+    public static double calculateMean(List<Integer> values) {
+        if (values == null || values.size() == 0) {
+            throw new IllegalArgumentException("Array must not be null or empty.");
+        }
+
+        double sum = 0.0;
+        for (double v : values) {
+            sum += v;
+        }
+
+        return sum / values.size();
     }
 
 

--- a/src/main/java/com/stocks/aggregator/utils/MathUtils.java
+++ b/src/main/java/com/stocks/aggregator/utils/MathUtils.java
@@ -1,5 +1,7 @@
 package com.stocks.aggregator.utils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -53,6 +55,20 @@ public class MathUtils {
         }
 
         return sum / values.size();
+    }
+    public static double trimmedMean(List<Integer> pips, double trimFraction) {
+        if (pips.isEmpty()) return 0.0;
+
+        List<Integer> sorted = new ArrayList<>(pips);
+        Collections.sort(sorted);
+
+        int n = sorted.size();
+        int trimCount = (int) (n * trimFraction);
+        int start = trimCount;
+        int end = n - trimCount;
+
+        List<Integer> trimmed = sorted.subList(start, end);
+        return trimmed.stream().mapToInt(i -> i).average().orElse(0.0);
     }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ application.name=SelfMonitoringApp
 spring.datasource.url=jdbc:mysql://localhost:3306/ylludb
 spring.datasource.username=root
 spring.datasource.password=wolsvagan
-spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 


### PR DESCRIPTION
Description:
This PR improves the logic used to calculate daily trading status by:

Introducing a more accurate monthly profit reset mechanism at month boundaries.

Reducing the impact of outlier trades when computing averages (e.g., pips per trade).

Optimizing data grouping by day and month to ensure consistent calculations.

Preparing the structure for future metrics like drawdown or volatility.